### PR TITLE
changed seperateQuat to do what it's name suggests and go along with …

### DIFF
--- a/Sources/armory/logicnode/SeparateQuatNode.hx
+++ b/Sources/armory/logicnode/SeparateQuatNode.hx
@@ -1,6 +1,5 @@
 package armory.logicnode;
 
-import iron.math.Mat4;
 import iron.math.Vec4;
 import iron.math.Quat;
 
@@ -14,13 +13,13 @@ class SeparateQuatNode extends LogicNode {
 
 
 	override function get(from:Int):Dynamic {		
-		var m:Mat4 = inputs[0].get();
+		var q:Quat = inputs[0].get();
 
-		if (from == 0) return m.getQuat().x;
-		else if (from == 1) return m.getQuat().y;
-		else if (from == 2) return m.getQuat().z;
-		else if (from == 3) return m.getQuat().w;
-		else return m.getQuat().getEuler();
+		if (from == 0) return q.x;
+		else if (from == 1) return q.y;
+		else if (from == 2) return q.z;
+		else if (from == 3) return q.w;
+		else return q.getEuler();
 		
 		}
 	}

--- a/blender.py
+++ b/blender.py
@@ -24,7 +24,7 @@ class SeparateQuatNode(Node, ArmLogicTreeNode):
     bl_icon = 'GAME'
 
     def init(self, context):
-        self.inputs.new('NodeSocketShader', 'Transform')
+        self.inputs.new('NodeSocketVector', 'Quat')
         self.outputs.new('NodeSocketFloat', 'X')
         self.outputs.new('NodeSocketFloat', 'Y')
         self.outputs.new('NodeSocketFloat', 'Z')


### PR DESCRIPTION
…changes in the API.

The node was expecting a transform as input despite being called SeperateQuat.
It was also incompatible with the current upstream amory/iron API. It seems like there no longer is a Mat4.getQuat() function.
So I changed it to use a quat as input.