### PR TITLE
Updated Lookin At Node

### DIFF
--- a/Sources/armory/logicnode/LookingAtNode.hx
+++ b/Sources/armory/logicnode/LookingAtNode.hx
@@ -5,7 +5,38 @@ import iron.math.Quat;
 import iron.object.Object;
 import armory.trait.physics.RigidBody;
 
- 
+/*
+abstract Vect4(Vec4) {
+	public inline function new(v:Vec4) {
+		this = v;
+	}
+
+	@:op(A + B)
+	public inline function add(v:Vec4):Vec4 {
+		return new Vec4(
+			this.x + v.x,
+			this.y + v.y,
+			this.z + v.z,
+			1);
+	}
+
+	@:op(A - B)
+	public inline function sub(v:Vec4):Vec4 {
+		return new Vec4(
+			this.x - v.x,
+			this.y - v.y,
+			this.z - v.z,
+			1);
+	}
+
+	// dot product
+	@:op(A * B)
+	public inline function dot(v:Vec4):Float {
+		return this.x * v.x + this.y * v.y + this.z * v.z;
+	}
+
+}
+*/
 class LookingAtNode extends LogicNode {
 	
 	public function new(tree:LogicTree) {
@@ -31,9 +62,16 @@ class LookingAtNode extends LogicNode {
 	private inline function multvec(v:Vec4, f:Float):Vec4 {
 		return new Vec4().setFrom(v).mult(f);
 	}
+
+	/**
+	 * projects a vector into the (normal) plane of another vector. The plane is assumed to pass through the origin.
+	 */
+	private inline function project(v:Vec4, plane:Vec4) {
+		return subvecs(v, multvec(plane, dotvecs(plane, v)));
+	}
 	
 	override function run() {
-		
+
 		// read inputs
 		var objFrom:Object = inputs[1].get();
 		var objTo:Object = inputs[2].get();
@@ -42,7 +80,28 @@ class LookingAtNode extends LogicNode {
 		var face:Vec4 = inputs[3].get().normalize();
 		var mainAxis:Vec4 = inputs[4].get().normalize();
 		
-		// rotate around main axis
+		// disable rotations
+		var disableMain:Bool = inputs[5].get();
+		var disableSecondary:Bool = inputs[6].get();
+
+		// restrict rotations
+		var restrictMain:Bool = inputs[7].get();
+		
+		var restrictMainMin:Float = inputs[8].get();
+		var restrictMainMax:Float = inputs[9].get();
+
+		var restrictSecondary:Bool = inputs[10].get();
+
+		var restrictSecondaryMin:Float = inputs[11].get();
+		var restrictSecondaryMax:Float = inputs[12].get();
+
+		var mainAngle:Float = 0;
+		var dist:Vec4 = subvecs(objTo.transform.world.getLoc(), objFrom.transform.world.getLoc());
+		
+		var inView:Bool = true;
+
+		if(!disableMain) {
+			// rotate around main axis
 		
 			// 1st
 			// use mainAxis as normal of a thought plane
@@ -59,44 +118,70 @@ class LookingAtNode extends LogicNode {
 			//4th
 			// reset the rotation of objFrom and rotate around the main axis by said angle
 		
-		// 1st
-		var dist:Vec4 = subvecs(objFrom.transform.world.getLoc(), objTo.transform.world.getLoc());
-		var projDistance:Vec4 = normalize(subvecs(dist, multvec(mainAxis, dotvecs(mainAxis, dist))));
+			// 1st
+			var projDistance:Vec4 = project(dist, mainAxis).normalize();
+
+			// 2nd
+			var projFace:Vec4 = project(face, mainAxis).normalize();
+
+			// 3rd
+			var tmpV:Vec4 = project(dist, face);
+			var tmpF:Float = dotvecs(tmpV, crossvecs(mainAxis, face));
+			mainAngle = Math.acos(projDistance.dot(projFace));
+			if(tmpF < 0)
+				mainAngle = -mainAngle;
+
+			if(restrictMain) {
+				if(mainAngle > restrictMainMax) {
+					mainAngle = restrictMainMax;
+					inView = false;
+				}
+				if(mainAngle < restrictMainMin) {
+					mainAngle = restrictMainMin;
+					inView = false;
+				}
+			}
+			trace(mainAngle);
+		}
 		
-		// trace(projDistance);
-		// 2nd
-		var projFace:Vec4 = normalize(subvecs(face, multvec(mainAxis, dotvecs(mainAxis, face))));
-		
-		// 3rd
-		var tmpV:Vec4 = subvecs(dist, multvec(face, dotvecs(face, dist)));
-		var tmpF:Float = dotvecs(tmpV, crossvecs(mainAxis, face));
-		var mainAngle:Float = Math.acos(projDistance.dot(projFace));
-		if(tmpF < 0)
-			mainAngle = -mainAngle;
-		
-		//var mainAngle:Float = Math.asin(projDistance.cross(projFace).length());
 		// 4th
 		objFrom.transform.setRotation(0, 0, 0);
 		objFrom.transform.rotate(mainAxis, mainAngle);
 		
-		// secondary rotation
+		if(!disableSecondary) {
+			// also rotate our face direction
+			face.applyAxisAngle(mainAxis, mainAngle);
+
+			// secondary rotation
 			// 1st
-			// normalize the main axis and the difference vector
+			// our distance vector needs to be in the same plane as our new facing and our mainAxis vector. This plane is described by the cross product of these two vectors.
+			// normalize the difference vector
 			// calculate the angle between them
-		
+
 			// 2nd
 			// rotate objFrom around the cross product of the normalized vectors by the new angle
 		
-		// 1st
-		var distNorm:Vec4 = dist.normalize();
-		var mainNorm:Vec4 = mainAxis.normalize();
+			// 1st
+			var projDistance:Vec4 = project(dist, crossvecs(mainAxis, face)).normalize();
+
+			var secondaryAngle:Float = -Math.acos(projDistance.dot(mainAxis)) + Math.PI/2;
 		
-		var secondaryAngle:Float = -Math.acos(distNorm.dot(mainNorm)) -Math.PI/2;
-		
-		// trace(secondaryAngle);
-		// 2nd
-		objFrom.transform.rotate(normalize(crossvecs(distNorm,mainNorm)), secondaryAngle);
-		
+			if(restrictSecondary) {
+				if(secondaryAngle > restrictSecondaryMax) {
+					secondaryAngle = restrictSecondaryMax;
+					inView = false;
+				}
+				if(secondaryAngle < restrictSecondaryMin) {
+					secondaryAngle = restrictSecondaryMin;
+					inView = false;
+				}
+			}
+
+			trace(secondaryAngle);
+			// 2nd
+			objFrom.transform.rotate(normalize(crossvecs(projDistance,mainAxis)), secondaryAngle);
+		}
+
 		objFrom.transform.buildMatrix();
 		
 		#if arm_physics

--- a/logicnode_definitions/action_looking_at.py
+++ b/logicnode_definitions/action_looking_at.py
@@ -15,5 +15,13 @@ class LookingAtNode(Node, ArmLogicTreeNode):
 		self.inputs.new('ArmNodeSocketObject', 'To Object')
 		self.inputs.new('NodeSocketVector', 'Front Facing')
 		self.inputs.new('NodeSocketVector', 'Main Rotation Axis')
+		self.inputs.new('NodeSocketBool', 'Disable Primary Roatation')
+		self.inputs.new('NodeSocketBool', 'Disable Secodary Roatation')
+		self.inputs.new('NodeSocketBool', 'Restrict Primary Rotation')
+		self.inputs.new('NodeSocketFloat', 'min Primary Rotation')
+		self.inputs.new('NodeSocketFloat', 'max Primary Rotation')
+		self.inputs.new('NodeSocketBool', 'Restrict Secondary Rotation')
+		self.inputs.new('NodeSocketFloat', 'min Secondary Rotation')
+		self.inputs.new('NodeSocketFloat', 'max Secondary Rotation')
 
 add_node(LookingAtNode, category='Action')

--- a/logicnode_definitions/action_looking_at.py
+++ b/logicnode_definitions/action_looking_at.py
@@ -10,9 +10,8 @@ class LookingAtNode(Node, ArmLogicTreeNode):
 	bl_icon = 'GAME'
 	
 	def init(self, context):
-		self.inputs.new('ArmNodeSocketAction', 'Activate')
-		self.inputs.new('ArmNodeSocketObject', 'From Object')
-		self.inputs.new('ArmNodeSocketObject', 'To Object')
+		self.inputs.new('NodeSocketVector', 'From Position')
+		self.inputs.new('NodeSocketVector', 'To Position')
 		self.inputs.new('NodeSocketVector', 'Front Facing')
 		self.inputs.new('NodeSocketVector', 'Main Rotation Axis')
 		self.inputs.new('NodeSocketBool', 'Disable Primary Roatation')
@@ -23,5 +22,8 @@ class LookingAtNode(Node, ArmLogicTreeNode):
 		self.inputs.new('NodeSocketBool', 'Restrict Secondary Rotation')
 		self.inputs.new('NodeSocketFloat', 'min Secondary Rotation')
 		self.inputs.new('NodeSocketFloat', 'max Secondary Rotation')
+		self.outputs.new('NodeSocketVector', 'Rotation (Euler)')
+		self.outputs.new('NodeSocketVector', 'Rotation (Quat)')
+		self.outputs.new('NodeSocketBool', 'Is in field of view')
 
 add_node(LookingAtNode, category='Action')


### PR DESCRIPTION
Changed the Looking At node to support constraints for primary and secondary rotation as well as the ability to disable either of them.
It also does not use a red input anymore, as it expects vectors now, instead of objects. It then outputs the calculated Rotation either as Euler or Quat to be used in a set rotation node. It can also tell whether the __toPosition__ is out of the rotation constraints.