### PR TITLE
Added Bool Operations and Number Compare

### DIFF
--- a/Sources/armory/logicnode/BoolOperationNode.hx
+++ b/Sources/armory/logicnode/BoolOperationNode.hx
@@ -1,0 +1,61 @@
+package armory.logicnode;
+
+class BoolOperationNode extends LogicNode {
+	
+	public var property0:String;
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function get(index:Int):Bool {
+		var result:Bool = false;
+		switch(property0) {
+			case "AND": {
+				result = true;
+				for(i in 1...inputs.length) {
+					if(!inputs[i].get()){
+						result = false;
+						break;
+					}
+				}
+			}
+			case "OR": {
+				result = false;
+				for(i in 1...inputs.length) {
+					if(inputs[i].get()){
+						result = true;
+						break;
+					}
+				}
+			}
+			case "EQUAL": {
+				result = inputs[1].get();
+				if(inputs.length == 2) {
+					result = true;
+				} else {
+					for(i in 2...inputs.length) {
+						trace(i);
+						if(inputs[i].get() != result) {
+							result = false;
+							break;
+						}
+					}
+				}
+			}
+			case "XOR": {
+				result = false;
+				for(i in 1...inputs.length) {
+					if(inputs[i].get()){
+						result = !result;
+					}
+				}
+			}
+			default: {
+				trace("This should not have happened. The BoolOperation Node ran into the default case and will thus always be false. Please report this error.");
+				return false;
+			}
+		}
+		inputs[0].get() ? return !result : return result;
+	}
+}

--- a/Sources/armory/logicnode/CompareNumberNode.hx
+++ b/Sources/armory/logicnode/CompareNumberNode.hx
@@ -1,0 +1,39 @@
+package armory.logicnode;
+
+class CompareNumberNode extends LogicNode {
+	
+	public var property0:String;
+	public var property1:Float;
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function get(index:Int):Bool {
+		var result:Bool = false;
+		switch(property0) {
+			case "EQUAL": {
+				return inputs[0].get() == inputs[1].get();
+			}
+			case "ALMOST EQUAL": {
+				return Math.abs(inputs[0].get() - inputs[1].get()) < property1;
+			}
+			case "LESS": {
+				return inputs[0].get() < inputs[1].get();
+			}
+			case "MORE": {
+				return inputs[0].get() > inputs[1].get();
+			}
+			case "LESS EQUAL": {
+				return inputs[0].get() <= inputs[1].get();
+			}
+			case "MORE EQUAL": {
+				return inputs[0].get() >= inputs[1].get();
+			}
+			default: {
+				trace("This should not have happened. The NumberCompare Node ran into the default case and will thus always be false. Please report this error.");
+				return false;
+			}
+		}
+	}
+} 

--- a/Sources/armory/logicnode/PlayerController.hx
+++ b/Sources/armory/logicnode/PlayerController.hx
@@ -6,8 +6,8 @@ import armory.trait.physics.RigidBody;
 
 class PlayerController extends LogicNode {
 
-	var isCrouching:Bool;
-	var lastKeyStateCrouch:Bool;
+	var isCrouching:Bool = false;
+	var lastKeyStateCrouch:Bool = false;
 
 	public function new(tree:LogicTree) {
 		super(tree);
@@ -43,8 +43,6 @@ class PlayerController extends LogicNode {
 		var crouchMult:Float = inputs[17].get();
 
 		if(player == null) return;
-		if(isCrouching == null) isCrouching = false;
-		if(lastKeyStateCrouch == null) lastKeyStateCrouch = false;
 		var loc = new Vec4(0, 0, 0);
 
 		// apply run Multiplier

--- a/logicnode_definitions/logic_bool_operation.py
+++ b/logicnode_definitions/logic_bool_operation.py
@@ -14,10 +14,6 @@ class BoolOperationNode(Node, ArmLogicTreeNode):
 				 ('OR', 'Or', 'True, if either of the inputs is true.'),
 				 ('XOR', 'Xor', 'True, when an uneven number of inputs is true.'),
 				 ('EQUAL', 'Equal', 'True, when both inputs are the same.'),
-				# ('Less', 'Less', 'Less'),
-				# ('More', 'More', 'More'),
-				# ('Less Equal', 'Less Equal', 'Less Equal'),
-				# ('More Equal', 'More Equal', 'More Equal'),
 				 ],
 		name='', default='AND')
 

--- a/logicnode_definitions/logic_bool_operation.py
+++ b/logicnode_definitions/logic_bool_operation.py
@@ -1,0 +1,43 @@
+import bpy
+from bpy.props import *
+from bpy.types import Node, NodeSocket
+from arm.logicnode.arm_nodes import *
+
+class BoolOperationNode(Node, ArmLogicTreeNode):
+	'''Boolean Operations'''
+	bl_idname = 'LNBoolOperationNode'
+	bl_label = 'Boolean Operation'
+	bl_icon = 'GAME'
+
+	property0 = EnumProperty(
+		items = [('AND', 'And', 'True, if both inputs are true.'),
+				 ('OR', 'Or', 'True, if either of the inputs is true.'),
+				 ('XOR', 'Xor', 'True, when an uneven number of inputs is true.'),
+				 ('EQUAL', 'Equal', 'True, when both inputs are the same.'),
+				# ('Less', 'Less', 'Less'),
+				# ('More', 'More', 'More'),
+				# ('Less Equal', 'Less Equal', 'Less Equal'),
+				# ('More Equal', 'More Equal', 'More Equal'),
+				 ],
+		name='', default='AND')
+
+	def __init__(self):
+		array_nodes[str(id(self))] = self
+
+	def init(self, context):
+		self.inputs.new('NodeSocketBool', 'Invert Output')
+		self.inputs.new('NodeSocketBool', 'Input 1')
+		self.inputs.new('NodeSocketBool', 'Input 2')
+		self.outputs.new('NodeSocketBool', 'Output')
+	
+	def draw_buttons(self, context, layout):
+		layout.prop(self, 'property0')
+		
+		row = layout.row(align=True)
+		add_button = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
+		add_button.node_index = str(id(self))
+		add_button.socket_type = 'NodeSocketBool'
+		remove_button =  row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
+		remove_button.node_index = str(id(self))
+
+add_node(BoolOperationNode, category='Logic')

--- a/logicnode_definitions/logic_bool_operation.py
+++ b/logicnode_definitions/logic_bool_operation.py
@@ -15,7 +15,7 @@ class BoolOperationNode(Node, ArmLogicTreeNode):
 				 ('XOR', 'Xor', 'True, when an uneven number of inputs is true.'),
 				 ('EQUAL', 'Equal', 'True, when both inputs are the same.'),
 				 ],
-		name='', default='AND')
+		name='Select Operation', default='AND')
 
 	def __init__(self):
 		array_nodes[str(id(self))] = self

--- a/logicnode_definitions/logic_number_compare.py
+++ b/logicnode_definitions/logic_number_compare.py
@@ -17,7 +17,7 @@ class CompareNumberNode(Node, ArmLogicTreeNode):
 				 ('LESS EQUAL', 'Less Equal', 'True, if A is less than or equal to B.'),
 				 ('MORE EQUAL', 'More Equal', 'True, if A is more than or equal to B.'),
 				 ],
-		name='', default='EQUAL')
+		name='Select Operation', default='EQUAL')
 
 	property1 = FloatProperty(name='Tolerance', description='Almost Equal threshold', default=0.0001)
 

--- a/logicnode_definitions/logic_number_compare.py
+++ b/logicnode_definitions/logic_number_compare.py
@@ -1,0 +1,34 @@
+import bpy
+from bpy.props import *
+from bpy.types import Node, NodeSocket
+from arm.logicnode.arm_nodes import *
+
+class CompareNumberNode(Node, ArmLogicTreeNode):
+	'''Compares two numbers'''
+	bl_idname = 'LNCompareNumberNode'
+	bl_label = 'Compare Numbers'
+	bl_icon = 'GAME'
+	
+	property0 = EnumProperty(
+		items = [('EQUAL', 'Equal', 'True, if both inputs are equal.'),
+				 ('ALMOST EQUAL', 'Almost Equal', 'True, if both inputs are almost (defined by threshold) equal.'),
+				 ('LESS', 'Less', 'True, if A is less than B.'),
+				 ('MORE', 'More', 'True, if A is more than B.'),
+				 ('LESS EQUAL', 'Less Equal', 'True, if A is less than or equal to B.'),
+				 ('MORE EQUAL', 'More Equal', 'True, if A is more than or equal to B.'),
+				 ],
+		name='', default='EQUAL')
+
+	property1 = FloatProperty(name='Tolerance', description='Almost Equal threshold', default=0.0001)
+
+	def init(self, context):
+		self.inputs.new('NodeSocketInt', 'A')
+		self.inputs.new('NodeSocketInt', 'B')
+		self.outputs.new('NodeSocketBool', 'Result')
+	
+	def draw_buttons(self, context, layout):
+		layout.prop(self, 'property0')
+		if self.property0 == 'ALMOST EQUAL':
+			layout.prop(self, 'property1')
+
+add_node(CompareNumberNode, category='Logic')


### PR DESCRIPTION
This pull request features two new Nodes. The first one takes an arbitary number of booleans and performs the speciefied opertation on them. The second node takes two numbers and compares them in the specified way.
The main difference of these nodes compared to the already existing Gate node is the separation of booleans and numbers as well as the missing "run" inputs/outputs. Thus, the (boolean) result of these nodes can be used directly as the input of other nodes (like "Is True" for creating something similar to "if" statements).

I was thinking about adding these nodes (and all other logic pack nodes) to a new "Logic Pack" category to seperate them from armorys internal/official nodes, but I wasn't shure whether that would be a good idea. What do you think of this?