### PR TITLE
added operator to save logic node setup into a library

### DIFF
--- a/logicnode_definitions/operator.py
+++ b/logicnode_definitions/operator.py
@@ -1,0 +1,189 @@
+import bpy
+import arm
+import os
+
+class SaveSelectedNodesOperator(bpy.types.Operator):
+    bl_idname = "node.save_selected_nodes"
+    bl_label = "Save Nodes To Library"
+
+    def execute(self, context):
+
+        library_name = "exported_nodes"
+        node_name = "exported_nodes"
+        fp = arm.utils.get_fp()
+
+        lfp = fp+"/Libraries"
+        
+        if not os.path.exists(lfp):
+            os.makedirs(lfp)
+
+        enfp = lfp+"/"+library_name
+        
+        if not os.path.exists(enfp):
+            os.makedirs(enfp)
+
+        # create blender.py to load the nodes
+        bl_file = open(enfp+"/blender.py", "w")
+        bl_file.write("import arm.nodes_logic\n")
+        bl_file.write("from node_definitions import *\n")
+        bl_file.write("def register():\n")
+        bl_file.write("\tarm.nodes_logic.register_nodes()\n")
+        
+        ndfp = enfp+"/node_definitions"
+
+        if not os.path.exists(ndfp):
+            os.makedirs(ndfp)
+
+        # create init so this dir can be imported
+
+        init_file = open(ndfp+"/__init__.py", "w")
+        init_file.write("# Import all nodes\n")
+        init_file.write("from os.path import dirname, basename, isfile\n")
+        init_file.write("import glob\n")
+        init_file.write("modules = glob.glob(dirname(__file__)+\"/*.py\")\n")
+        init_file.write("__all__ = [basename(f)[:-3] for f in modules if isfile(f)]\n")
+
+        # since the file name is hardcoded, append an index to avoid overriding the file
+        file_name = node_name + "_"
+        index = 0
+        while os.path.isfile(ndfp+"/"+file_name+str(index)+".py"):
+            index += 1
+        file_name += str(index) + ".py"
+            
+        node_file = open(ndfp+"/"+file_name,"w")
+        node_file.write("import bpy\n")
+        node_file.write("from bpy.props import *\n")
+        node_file.write("from bpy.types import Node, NodeSocket\n")
+        node_file.write("from arm.logicnode.arm_nodes import *\n")
+        
+        # give the node the same name that is used for the file for now...
+        node_file.write("class {0}(Node, ArmLogicTreeNode):\n".format(node_name+"_"+str(index)))
+        node_file.write("\t'''{0}'''\n".format(node_name+"_"+str(index)))
+        node_file.write("\tbl_idname=\"LN{0}\"\n".format(node_name+"_"+str(index)))
+        node_file.write("\tbl_label=\"{0}\"\n".format(node_name+"_"+str(index)))
+        node_file.write("\tbl_icon=\"QUESTION\"\n")
+        
+        node_file.write("\tdef init(self, context):\n")
+        node_file.write("\t\t# convenience functions\n")
+        node_file.write("\t\tdef placeNodeWithOffset(node, reference, offset):\n")
+        node_file.write("\t\t\tnode.location = [reference[0]+offset[0], reference[1]+offset[1]]\n\n")
+            
+        # node_file.write("\t\tdef selectNodes(node_tree, nodes):\n")
+        # node_file.write("\t\t\tfor node in nodes:\n")
+        # node_file.write("\t\t\t\tnode.select = True\n\n")
+                    
+        # node_file.write("\t\tdef frameNodes(node_tree, nodes, title):\n")
+        # node_file.write("\t\t\tbpy.ops.node.select_all(action='DESELECT')\n")
+        # node_file.write("\t\t\tselectNodes(node_tree, nodes)\n")
+        # node_file.write("\t\t\tbpy.ops.node.join()\n")
+        # node_file.write("\t\t\tframe = node_tree.active\n")
+        # node_file.write("\t\t\tframe.label = title\n")
+        # node_file.write("\t\t\treturn frame\n\n")
+            
+        node_file.write("\t\tdef linkNodes(node_links, node_1, node_2, output_socket_index, input_socket_index):\n")
+        node_file.write("\t\t\tlinks.new(node_1.outputs[output_socket_index], node_2.inputs[input_socket_index])\n\n")
+
+        node_file.write("\t\t# easy access\n")
+        node_file.write("\t\tnode_tree_nodes = bpy.context.space_data.node_tree.nodes\n")
+        node_file.write("\t\tlinks = bpy.context.space_data.node_tree.links\n")
+        node_file.write("\t\tloc = bpy.context.space_data.cursor_location\n\n")
+        
+        
+        node_tree = context.space_data.node_tree
+        nodes = context.selected_nodes
+        links = node_tree.links
+
+        node_file.write("\t\t# add nodes to the tree\n")
+        averageX = 0
+        averageY = 0
+        # add all nodes, also "compute" the average location
+        for node in nodes:
+            node_file.write("\t\tnode_{0} = node_tree_nodes.new(\"{1}\")\n".format(node.name.replace(".", "_").replace(" ", "_"), node.bl_idname))
+            averageX += node.location[0]/len(nodes)
+            averageY += node.location[1]/len(nodes)
+        
+        # position nodes, based on their distance to the average location
+        node_file.write("\t\t# create node layout\n")
+        for node in nodes:
+            # print(node.bl_idname)
+            if node.bl_idname != "NodeFrame":
+                node_file.write("\t\tplaceNodeWithOffset(node_{0}, loc, [{1}, {2}])\n".format(node.name.replace(".", "_").replace(" ", "_"), node.location[0]-averageX, node.location[1]-averageY))
+                
+        # handle frames
+        node_file.write("\t\t# handle parenting, this is needed for frames\n")
+        for node in nodes:
+            if node.parent is not None:
+                node_file.write("\t\tnode_{0}.parent = node_{1}\n".format(node.name.replace(".", "_").replace(" ", "_"), node.parent.name.replace(".", "_").replace(" ", "_")))
+
+        # handle labels
+        node_file.write("\t\t# create labels\n")
+        for node in nodes:
+            node_file.write("\t\tnode_{0}.label = \"{1}\"\n".format(node.name.replace(".", "_").replace(" ", "_"), node.label))
+
+        # handle values
+        node_file.write("\t\t# set default input values\n")
+        for node in nodes:
+            for i in range(0, len(node.inputs)):
+                inp = node.inputs[0]
+                if "default_value" in dir(inp):
+                    # print(type(inp.default_value))
+                    if type(inp.default_value) is bpy.types.bpy_prop_array:
+                        # print("Array")
+                        for x in range(0, len(inp.default_value)):
+                            # so string arrays even exist in blender nodes?
+                            if type(inp.default_value[x]) is str:
+                                node_file.write("\t\tnode_{0}.inputs.[{1}].default_value[{2}] = \"{3}\"\n".format(node.name.replace(".", "_").replace(" ", "_"), i, x, inp.default_value[x]))
+                            else:
+                                node_file.write("\t\tnode_{0}.inputs[{1}].default_value[{2}] = {3}\n".format(node.name.replace(".", "_").replace(" ", "_"), i, x, inp.default_value[x]))
+                    else:
+                        if type(inp.default_value) is str:
+                            node_file.write("\t\tnode_{0}.inputs[{1}].default_value = \"{2}\"\n".format(node.name.replace(".", "_").replace(" ", "_"), i, inp.default_value))
+                        else:
+                            node_file.write("\t\tnode_{0}.inputs[{1}].default_value = {2}\n".format(node.name.replace(".", "_").replace(" ", "_"), i, inp.default_value))
+                            # node_file.write("\t\tnode_{0}.label = \"{1}\"\n".format(node.name.replace(".", "_").replace(" ", "_"), node.label))
+
+        # handle properties
+        node_file.write("\t\t# set node properties like add/subtract on math node\n")
+        for node in nodes:
+            # print(dir(node))
+            # print(node.__dir__)
+            for attrib in dir(node):
+                if attrib.startswith("property"):
+                    # print(attrib)
+                    # print(type(getattr(node, attrib)).__name__)
+                    # print(callable(getattr(node, attrib)))
+                    # print(node.__dict__)
+                    # print(node.bl_idname)
+                    # print(dir(node))
+                    # print(attrib)
+                    node_file.write("\t\ttry:\n")
+                    if type(getattr(node, attrib)).__name__ == "str":
+                        node_file.write("\t\t\tnode_{0}.{1} = \"{2}\"\n".format(node.name.replace(".", "_").replace(" ", "_"), attrib, getattr(node, attrib)))
+                    else:
+                        node_file.write("\t\t\tnode_{0}.{1} = {2}\n".format(node.name.replace(".", "_").replace(" ", "_"), attrib, getattr(node, attrib)))
+                    node_file.write("\t\texcept:\n")
+                    # this notifies a user of properties which failed to apply, not needed, only helpful for debugging
+                    # node_file.write("\t\t\tprint(\"could not set {0} to {1} on node_{2}, this is most likely not problematic\")\n".format(attrib, getattr(node, attrib), node.name.replace(".", "_").replace(" ", "_")))
+                    node_file.write("\t\t\tpass\n")
+
+        # link nodes
+        node_file.write("\t\t# create node links\n")
+        for link in links:
+            if link.from_node in nodes and link.to_node in nodes:
+                # use path_from_id() to get somthing like nodes["Float"].outputs[0], then reverse with [::-1]
+                # then use split to get only the part containing the index, reverse again, so the number is right and split again to remove the last bracket
+                # somewhat like to cut | rev | cut ... in bash
+                # print(link.from_socket.path_from_id()[::-1].split("[")[0][::-1].split("]")[0])
+                node_file.write("\t\tlinkNodes(links, node_{0}, node_{1}, {2}, {3})\n".format(link.from_node.name.replace(".", "_").replace(" ", "_"), link.to_node.name.replace(".", "_").replace(" ", "_"), link.from_socket.path_from_id()[::-1].split("[")[0][::-1].split("]")[0], link.to_socket.path_from_id()[::-1].split("[")[0][::-1].split("]")[0]))
+
+        # remove meta node
+        node_file.write("\t\tnode_tree_nodes.remove(self)\n")
+        # add node to armory
+        node_file.write("add_node({0}, category='{1}')".format(node_name+"_"+str(index), "Test"))
+        return {'FINISHED'}
+    
+    @classmethod
+    def poll(cls, context):
+        return context.space_data != None and context.space_data.type == 'NODE_EDITOR'
+
+bpy.utils.register_class(SaveSelectedNodesOperator)


### PR DESCRIPTION
This adds an operator to the logic nodes.
It is called "Save selected nodes to library" and can be activated via F3.
It basically does what it's name says:
If not yet present, it creates a libraray "exported_nodes", which is structured like this logic pack (uses the same file structure, blender.py and __init__.py).
It then creates a exported_nodes_#.py, which represents the new node.
This is done by (ab)using the init function of a node to add/configure other nodes.
The exported node contains all nodes/links which were selected when the operator was called.
I already posted about this in the forum [here](http://forums.armory3d.org/t/ab-using-a-nodes-init-function/2937).

Currently the name is hardcoded, which leads to the nodes being named "exported_nodes_#".
In the future, I would like it to be able to create some popup menu in which the node/library and file name can be defined prior to exporting.