### PR TITLE
Remove faulty default values for some node sockets

### DIFF
--- a/logicnode_definitions/action_camera_controller.py
+++ b/logicnode_definitions/action_camera_controller.py
@@ -21,9 +21,9 @@ class CameraController(ArmLogicTreeNode):
 
         self.add_input('ArmNodeSocketAction', 'Activate')
 
-        self.add_input('ArmNodeSocketObject', 'Player Object', default_value='Player')
+        self.add_input('ArmNodeSocketObject', 'Player Object')
 
-        self.add_input('ArmNodeSocketObject', 'Camera Object', default_value='Camera')
+        self.add_input('ArmNodeSocketObject', 'Camera Object')
 
         self.add_input('NodeSocketFloat', 'Speed Modifier', default_value=1.0)
         self.add_input('NodeSocketBool', 'Additional Modifier (e.g. sniper)')

--- a/logicnode_definitions/action_player_controller.py
+++ b/logicnode_definitions/action_player_controller.py
@@ -21,7 +21,7 @@ class PlayerController(ArmLogicTreeNode):
 
         self.add_input('ArmNodeSocketAction', 'Activate')
 
-        self.add_input('ArmNodeSocketObject', 'Player Object', default_value='Player')
+        self.add_input('ArmNodeSocketObject', 'Player Object')
 
         self.add_input('NodeSocketFloat', 'Overall Speed Modifier', default_value=1.0)
 

--- a/logicnode_definitions/animation_animation_controller.py
+++ b/logicnode_definitions/animation_animation_controller.py
@@ -24,8 +24,8 @@ class AnimationControllerNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketAction', 'Done')
 
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Animated Object', default_value='Animated Object')
-        self.add_input('ArmNodeSocketAnimAction', 'Idle', default_value='Idle')
+        self.add_input('ArmNodeSocketObject', 'Animated Object')
+        self.add_input('ArmNodeSocketAnimAction', 'Idle')
         self.add_input('NodeSocketFloat', 'Blend Time', default_value=0.2)
 
 


### PR DESCRIPTION
Fixes an exception when adding the now changed nodes to a tree. Probably a remnant of the past when object and animation sockets used strings in the UI.